### PR TITLE
test(runner-core): fix incorrect assertion in unit tests

### DIFF
--- a/runner/core/test/workspace.spec.ts
+++ b/runner/core/test/workspace.spec.ts
@@ -47,13 +47,17 @@ describe('[class] workspace', () => {
       });
       stubs.cacheRead.resolves(null);
       stubs.cacheWrite.resolves();
-      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe((result) => {
-        expect(result.overall).toBeGreaterThan(0);
-        expect(result.fromCache).toBe(false);
-        expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
-      }, (e) => {
-        expect(e).toBeFalsy();
-      }, () => done());
+      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe({
+        next: (result) => {
+          expect(result.overall).toBeGreaterThan(200);
+          expect(result.fromCache).toBe(false);
+          expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
+        },
+        error: (e) => {
+          expect(e).toBeFalsy();
+        },
+        complete: () => done(),
+      });
     });
     it('should run a given target and emit process result - from cache', (done) => {
       const workspace = new Workspace({} as any, '', {
@@ -65,13 +69,16 @@ describe('[class] workspace', () => {
       });
       stubs.cacheRead.resolves([{ stdout: 'Hello world' }]);
       stubs.cacheWrite.resolves();
-      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe((result) => {
-        expect(result.overall).toBeGreaterThan(0);
-        expect(result.fromCache).toBe(true);
-        expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
-      }, (e) => {
-        expect(e).toBeFalsy();
-      }, () => done());
+      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe({
+        next: (result) => {
+          expect(result.fromCache).toBe(true);
+          expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
+        },
+        error: (e) => {
+          expect(e).toBeFalsy();
+        },
+        complete: () => done()
+      });
     });
     it('should run a given target and emit process result - cache read fails', (done) => {
       const workspace = new Workspace({} as any, '', {
@@ -83,13 +90,17 @@ describe('[class] workspace', () => {
       });
       stubs.cacheRead.rejects();
       stubs.cacheWrite.resolves();
-      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe((result) => {
-        expect(result.overall).toBeGreaterThanOrEqual(0);
-        expect(result.fromCache).toBe(false);
-        expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
-      }, (e) => {
-        expect(e).toBeFalsy();
-      }, () => done());
+      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe({
+        next: (result) => {
+          expect(result.overall).toBeGreaterThan(200);
+          expect(result.fromCache).toBe(false);
+          expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
+        },
+        error: (e) => {
+          expect(e).toBeFalsy();
+        },
+        complete: () => done()
+      });
     });
     it('should run a given target and emit process result - cache write fails', (done) => {
       const workspace = new Workspace({} as any, '', {
@@ -101,13 +112,17 @@ describe('[class] workspace', () => {
       });
       stubs.cacheRead.resolves(null);
       stubs.cacheWrite.rejects();
-      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe((result) => {
-        expect(result.overall).toBeGreaterThan(0);
-        expect(result.fromCache).toBe(false);
-        expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
-      }, (e) => {
-        expect(e).toBeFalsy();
-      }, () => done());
+      workspace.run({ cmd: 'foo', mode: 'topological' }).subscribe({
+        next: (result) => {
+          expect(result.overall).toBeGreaterThan(200);
+          expect(result.fromCache).toBe(false);
+          expect((result.commands[0] as ICommandResult).stdout).toBe('Hello world')
+        },
+        error: (e) => {
+          expect(e).toBeFalsy();
+        },
+        complete: () => done()
+      });
     });
     it('should run a given target and emit error', (done) => {
       const workspace = new Workspace({} as any, '', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,7 +2552,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microlambda/aws@1.0.0-alpha.26, @microlambda/aws@workspace:*, @microlambda/aws@workspace:aws":
+"@microlambda/aws@1.0.0-alpha.29, @microlambda/aws@workspace:*, @microlambda/aws@workspace:aws":
   version: 0.0.0-use.local
   resolution: "@microlambda/aws@workspace:aws"
   dependencies:
@@ -2643,7 +2643,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@microlambda/core@1.0.0-alpha.26, @microlambda/core@workspace:*, @microlambda/core@workspace:core":
+"@microlambda/core@1.0.0-alpha.29, @microlambda/core@workspace:*, @microlambda/core@workspace:core":
   version: 0.0.0-use.local
   resolution: "@microlambda/core@workspace:core"
   dependencies:
@@ -2721,7 +2721,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@microlambda/layers@1.0.0-alpha.26, @microlambda/layers@workspace:layers":
+"@microlambda/layers@1.0.0-alpha.29, @microlambda/layers@workspace:layers":
   version: 0.0.0-use.local
   resolution: "@microlambda/layers@workspace:layers"
   dependencies:
@@ -2774,7 +2774,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@microlambda/runner-core@1.0.0-alpha.26, @microlambda/runner-core@workspace:*, @microlambda/runner-core@workspace:runner/core":
+"@microlambda/runner-core@1.0.0-alpha.29, @microlambda/runner-core@workspace:*, @microlambda/runner-core@workspace:runner/core":
   version: 0.0.0-use.local
   resolution: "@microlambda/runner-core@workspace:runner/core"
   dependencies:
@@ -2832,7 +2832,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@microlambda/types@1.0.0-alpha.26, @microlambda/types@workspace:*, @microlambda/types@workspace:types":
+"@microlambda/types@1.0.0-alpha.29, @microlambda/types@workspace:*, @microlambda/types@workspace:types":
   version: 0.0.0-use.local
   resolution: "@microlambda/types@workspace:types"
   languageName: unknown
@@ -11932,11 +11932,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "serverless-microlambda@workspace:plugin"
   dependencies:
-    "@microlambda/aws": 1.0.0-alpha.26
-    "@microlambda/core": 1.0.0-alpha.26
-    "@microlambda/layers": 1.0.0-alpha.26
-    "@microlambda/runner-core": 1.0.0-alpha.26
-    "@microlambda/types": 1.0.0-alpha.26
+    "@microlambda/aws": 1.0.0-alpha.29
+    "@microlambda/core": 1.0.0-alpha.29
+    "@microlambda/layers": 1.0.0-alpha.29
+    "@microlambda/runner-core": 1.0.0-alpha.29
+    "@microlambda/types": 1.0.0-alpha.29
     chokidar: ^3.5.2
     hasha: ^5.2.2
     joi: ^17.4.2


### PR DESCRIPTION
As mocked process exits after 200ms, assert overall > 200ms in tests where script should actually be run.
In test cases where result is read from cache, no assertion can be made on overall as it is cache read time.

Fix #32 