### PR TITLE
Draft: canary releases

### DIFF
--- a/cli/src/cmd/canary.ts
+++ b/cli/src/cmd/canary.ts
@@ -1,0 +1,32 @@
+import chalk from "chalk";
+import Table from "cli-table3";
+import {State} from "@microlambda/remote-state";
+import {ConfigReader} from "@microlambda/config";
+import {resolveProjectRoot} from "@microlambda/utils";
+import {logger} from "../utils/logger";
+
+export const printCanaryVersions = async (cmd: {e: string}): Promise<void> => {
+  const state = new State(new ConfigReader(resolveProjectRoot()).rootConfig);
+  const versions = await state.listVersions(cmd.e);
+
+  logger.lf();
+  logger.info(chalk.underline(chalk.bold(`▼ Versions history for ${cmd.e}`)));
+  logger.lf();
+
+  const table = new Table({
+    head: ['version', 'status', 'createdAt'],
+    style: {
+      head: ['cyan']
+    }
+  });
+  for (const version of versions.sort((v1, v2) => v2.createdAt.localeCompare(v1.createdAt))) {
+    const row = ['v' + version.version, version.active ? 'active' : 'inactive', version.createdAt];
+    table.push(row);
+  }
+  // eslint-disable-next-line no-console
+  console.log(table.toString());
+}
+
+export const cleanCanaryVersion = async (cmd: {e: string, v: string}): Promise<void> => {
+
+}

--- a/cli/src/cmd/remove.ts
+++ b/cli/src/cmd/remove.ts
@@ -52,7 +52,6 @@ export const remove = async (cmd: IDeployCmd): Promise<void> => {
 
     const spinnies = new MilaSpinnies(cmd.verbose);
 
-
     const failures: Set<DeployEvent> = new Set();
     const actions: Set<DeployEvent> = new Set();
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import { destroyEnv } from './cmd/envs/destroy';
 import { createReplicate } from './cmd/envs/create-replicate';
 import { destroyReplicate } from './cmd/envs/destroy-replicate';
 import { runTests } from './cmd/run-tests';
+import {cleanCanaryVersion, printCanaryVersions} from "./cmd/canary";
 
 const program = new Command();
 
@@ -244,6 +245,7 @@ program
   .option('--no-prompt', 'skip asking user confirmation before deploying', false)
   .option('--skip-lock', 'ignore lock and perform the actions anyway', false)
   .option('--only-prompt', 'only display deployment information and return', false)
+  .option('--canary', 'create a new canary release.', false)
   .description('deploy services to AWS')
   .action(
     async (cmd) =>
@@ -251,6 +253,23 @@ program
         await deploy(cmd);
       }, true),
   );
+
+program.command('canary')
+  .requiredOption('-e <stage>, --stage <stage>', 'target stage for canary release actions')
+  .action(
+    async (cmd) =>
+      await commandWrapper(async () => {
+        await printCanaryVersions(cmd);
+      }),
+  )
+  .command('destroy')
+  .requiredOption('-v <version>, --version <version>', 'the version to clean')
+  .action(
+    async (cmd) =>
+      await commandWrapper(async () => {
+        await cleanCanaryVersion(cmd);
+      }),
+  )
 
 // FIXME
 program

--- a/cli/src/utils/deploy/cmd-options.ts
+++ b/cli/src/utils/deploy/cmd-options.ts
@@ -6,4 +6,5 @@ export interface IDeployCmd extends IPackageCmd {
   onlyPrompt: boolean;
   forceDeploy: boolean;
   skipLock: boolean;
+  canary: boolean;
 }

--- a/cli/src/utils/deploy/resolve-deltas.ts
+++ b/cli/src/utils/deploy/resolve-deltas.ts
@@ -48,7 +48,7 @@ export const resolveDeltas = async (
         serviceOperations.set(targetRegion, 'first_deploy');
       } else {
         try {
-          if (cmd.force || cmd.forcePackage || cmd.forceDeploy) {
+          if (cmd.force || cmd.forcePackage || cmd.forceDeploy || cmd.canary) {
             serviceOperations.set(targetRegion, 'redeploy');
             continue;
           }

--- a/core/src/deploy.ts
+++ b/core/src/deploy.ts
@@ -25,6 +25,7 @@ export class Deployer {
     readonly options: IDeployOptions,
     readonly mode: 'deploy' | 'remove' = 'deploy',
     readonly logger?: EventsLog,
+    readonly env: Record<string, string> = {},
   ) {
     this._reader = new ConfigReader(logger);
     this._reader.validate(options.project);
@@ -42,7 +43,7 @@ export class Deployer {
       mode: 'parallel',
       force: this.options.force,
       args: [],
-      env: { AWS_REGION: region }
+      env: { AWS_REGION: region, ...this.env }
     }).pipe(map((evt) => ({...evt, region})));
   }
 

--- a/plugin/src/features/canary/patch-stack-name.ts
+++ b/plugin/src/features/canary/patch-stack-name.ts
@@ -1,0 +1,19 @@
+import {State} from "@microlambda/remote-state";
+import {IRootConfig} from "@microlambda/config";
+import {IBaseLogger, ServerlessInstance} from "@microlambda/types";
+
+export const patchServiceName = async (serverless: ServerlessInstance, config: IRootConfig | undefined, env: string, logger: IBaseLogger): Promise<void> => {
+  if (!config) {
+    logger.error('Assertion failed: unresolved config');
+    throw new Error('Assertion failed: unresolved config');
+  }
+  const state = new State(config);
+  const _env = await state.findEnv(env);
+  if (_env.useCanary && _env.currentVersion) {
+    logger.info(`Notice: this service uses canary release`);
+    logger.info('The current version for this service is', _env.currentVersion);
+    const updatedStackName = serverless.service + '-v' + _env.currentVersion;
+    logger.info('Deploying stack', updatedStackName);
+    serverless.service = updatedStackName;
+  }
+}


### PR DESCRIPTION
The part "deploy a new canary release" is done.

The part "remove previous version" is harder than expected:

A serverless remove command should be performed for each microservice at the last deployed git state for the version.

The git state may be different for each service as partial redeployments may happen (due to specific user input or remote caching).

To finalize the feature we should store for each service,env,version the last successful deployed git sha1.