### PR TITLE
Draft: naming conventions

### DIFF
--- a/config/src/schemas/naming-conventions.ts
+++ b/config/src/schemas/naming-conventions.ts
@@ -1,0 +1,8 @@
+import joi from "joi";
+
+export const namingConventions = joi.object().keys({
+  stack: joi.string().optional(),
+  api: joi.string().optional(),
+  iam: joi.string().optional(),
+  handlers: joi.string().optional(),
+}).optional();

--- a/config/src/schemas/package-config.ts
+++ b/config/src/schemas/package-config.ts
@@ -1,9 +1,11 @@
 import joi from 'joi';
 import { targetsConfigSchema } from './target-config';
 import { regions } from '../regions';
+import {namingConventions} from "./naming-conventions";
 
 export const packageConfigSchema = joi.object().keys({
   extends: joi.string().optional(),
   targets: targetsConfigSchema.optional(),
   regions: joi.array().items(joi.string().valid(...regions).required()).optional(),
+  namingConventions,
 })

--- a/config/src/schemas/root-config.ts
+++ b/config/src/schemas/root-config.ts
@@ -1,6 +1,7 @@
 import joi from 'joi';
 import { regions } from '../regions';
 import { targetsConfigSchema } from './target-config';
+import {namingConventions} from "./naming-conventions";
 
 export const rootConfigSchema = joi.object().keys({
   defaultRegion: joi.string().valid(...regions).required(),
@@ -14,4 +15,5 @@ export const rootConfigSchema = joi.object().keys({
     env: joi.string().optional(),
   }).optional(),
   targets: targetsConfigSchema.optional(),
+  namingConventions,
 });

--- a/config/src/types/package-config.ts
+++ b/config/src/types/package-config.ts
@@ -45,4 +45,10 @@ export interface IPackageConfig {
     [cmd: string]: ITargetConfig;
   }
   extends?: string;
+  namingConventions?: {
+    "stack"?: string;
+    "api"?: string;
+    "handlers"?: string;
+    "iam"?: string;
+  }
 }

--- a/config/src/types/root-config.ts
+++ b/config/src/types/root-config.ts
@@ -12,4 +12,10 @@ export interface IRootConfig {
     "env"?: string;
   },
   "targets"?: ITargetsConfig;
+  "namingConventions"?: {
+    "stack"?: string;
+    "api"?: string;
+    "handlers"?: string;
+    "iam"?: string;
+  }
 }

--- a/plugin/src/features/naming-conventions/update-resources-names.ts
+++ b/plugin/src/features/naming-conventions/update-resources-names.ts
@@ -1,0 +1,67 @@
+import {IPackageConfig, IRootConfig} from "@microlambda/config";
+import {IBaseLogger, ServerlessInstance} from "@microlambda/types";
+
+export const updateResourcesNames = (options: {
+  env: string,
+  serverless: ServerlessInstance,
+  rootConfig: IRootConfig,
+  serviceConfig: IPackageConfig,
+  serviceName: string;
+  currentVersion: number;
+}, logger: IBaseLogger): void => {
+  const { env, serviceName, serverless, rootConfig, serviceConfig } = options;
+  const resolveNamePattern = (key: 'api' | 'stack' | 'iam' | 'handlers'): string | undefined => {
+    if (serviceConfig.namingConventions && serviceConfig.namingConventions[key]) {
+      return serviceConfig.namingConventions[key];
+    }
+    if (rootConfig.namingConventions && rootConfig.namingConventions[key]) {
+      return rootConfig.namingConventions[key];
+    }
+    return undefined;
+  }
+
+  const interpolatePattern = (pattern: string): string => {
+    return pattern
+      .replace('$env', env)
+      .replace('$service', serviceName)
+      .replace('$version', options.currentVersion.toString())
+  }
+
+  const interpolateForHandlers = (pattern: string, handlerName: string): string => {
+    const handler = serverless.service.functions[handlerName].handler;
+    const fileName = handler.match(/.+\/(.+)\.(.+)$/)[1];
+    return interpolatePattern(pattern).replace('$handlerName', handlerName).replace('$fileName', fileName);
+  }
+
+  if (rootConfig.namingConventions || serviceConfig.namingConventions) {
+
+    const patterns = {
+      api: resolveNamePattern('api'),
+      stack: resolveNamePattern('stack'),
+      handlers: resolveNamePattern('handlers'),
+      iam: resolveNamePattern('iam'),
+    }
+
+    if (!serverless.service.provider.stackName && patterns.stack) {
+      serverless.service.provider.stackName = interpolatePattern(patterns.stack);
+      logger.info('Naming conventions - Replacing stack name:', interpolatePattern(patterns.stack));
+    }
+
+    if (!serverless.service.provider.apiName && patterns.api) {
+      serverless.service.provider.apiName = interpolatePattern(patterns.api);
+      logger.info('Naming conventions - Replacing API Gateway name:', interpolatePattern(patterns.api));
+    }
+
+    if (!serverless.service.provider.iam.role.name && patterns.iam) {
+      serverless.service.provider.iam.role.name = interpolatePattern(patterns.iam);
+      logger.info('Naming conventions - Replacing Lambda IAM Role name:', interpolatePattern(patterns.iam));
+    }
+
+    Object.keys(serverless.service.functions).forEach((handlerName) => {
+      if (!serverless.service.functions[handlerName].name && patterns.handlers) {
+        serverless.service.functions[handlerName].name = interpolateForHandlers(patterns.handlers, handlerName);
+        logger.info('Naming conventions - Replacing Lambda function name:', interpolateForHandlers(patterns.handlers, handlerName));
+      }
+    })
+  }
+}

--- a/types/src/plugin/serverless.ts
+++ b/types/src/plugin/serverless.ts
@@ -6,7 +6,8 @@ export interface ServerlessInstance {
     service: string;
     provider: {
       stage: string;
-      stackName: string;
+      stackName?: string;
+      apiName?: string;
       compiledCloudFormationTemplate: {
         Outputs: unknown;
       };
@@ -18,6 +19,11 @@ export interface ServerlessInstance {
       architecture: 'x86_64' | 'arm64';
       runtime: LambdaRuntimes;
       environment: { [key:string]: string};
+      iam: {
+        role: {
+          name?: string;
+        }
+      }
     };
     custom: {
       [key: string]: unknown;
@@ -25,10 +31,11 @@ export interface ServerlessInstance {
     getAllFunctions: () => string[];
     functions: {
       [key: string]: {
-        name: string;
-        architecture: 'x86_64' | 'arm64';
-        runtime: LambdaRuntimes;
-        events: Array<{
+        name?: string;
+        architecture?: 'x86_64' | 'arm64';
+        runtime?: LambdaRuntimes;
+        handler: string;
+        events?: Array<{
           http?: { authorizer?: Partial<IAuthorizerConfig> };
           websocket?: { authorizer?: Partial<IAuthorizerConfig> };
         }>;


### PR DESCRIPTION
This task conflicts the canary release feature.

Automatic resource naming performed by the serverless framework includes service name (as in yaml root) in resources names.

Thus, we are pretty sure that all resources have distinct names between to different canary versions.

When user uses both naming convention and canary release on a specific environment, we should check on predeploy that each name conventions includes `$version` pseudo-variable or crash.